### PR TITLE
feat(*): configure logger via Environment. Log to stderr by default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,7 @@
+## Changelog
+
+#### v2.1
+
+* log to stdout by default
+* introduces environment variable for logger configuration
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # composer-logger-service-provider
+
 ETNA logger service provider
+
+## Configuration
+
+The logger is configured via environment variables:
+
+| Variable              | Exemple                                          | Description                                                                |
+|-----------------------|--------------------------------------------------|----------------------------------------------------------------------------|
+| `ETNA_LOGLEVEL`       | `debug`, `info` , `warning`, `error`, `critical` | log level. default to `debug` if running on debug, `info` otherwise.       |
+| `ETNA_LOGFILE`        | `/var/log/myapp.log`                             | path to a file, where to output logs. Using it disables logging to stderr. |
+| `ETNA_SYSLOG_ENABLED` | `true`, `yes`, `1`, `false`, `no`, `0`           | Enable syslog logging                                                      |
+

--- a/src/ETNALogger.php
+++ b/src/ETNALogger.php
@@ -12,6 +12,10 @@ use Monolog\Handler\SyslogHandler;
 use Monolog\Handler\SlackHandler;
 use Monolog\Logger;
 
+/**
+ *  $app['logs']: log provider for Etna Apps.
+ *  - default logging on stderr
+ */
 class ETNALogger implements ServiceProviderInterface
 {
     /**
@@ -20,42 +24,57 @@ class ETNALogger implements ServiceProviderInterface
      */
     public function register(Container $app)
     {
-        if (true !== isset($app["application_path"])) {
-            throw new \Exception('$app["application_path"] is not set');
-        }
-
         if (true !== isset($app["application_name"])) {
             throw new \Exception('$app["application_name"] is not set');
         }
-
         $app_name = $app["application_name"];
+        $is_debug_enabled = isset($app["debug"]) && (true === $app['debug']);
+        $log_level = $this->get_log_level($is_debug_enabled);
 
-        $app->register(
-            new MonologServiceProvider(),
-            [
-                'monolog.logfile'               => "{$app["application_path"]}/tmp/log/{$app_name}.log",
-                'monolog.name'                  => $app_name,
-                'monolog.level'                 => (true === $app['debug']) ? Logger::DEBUG : Logger::ERROR,
-                'monolog.fingerscrossed.level'  => Logger::CRITICAL,
-                'monolog.rotatingfile'          => true,
-                'monolog.rotatingfile.maxfiles' => 7
-            ]
-        );
+        // The fingerCrossed level allows live redefinition of the log level: When a log
+        // with level above threshold is emitted, then the log level will be lowered.
+        $monolog_options = [
+            'monolog.name'                  => $app_name,
+            'monolog.level'                 => $log_level,
+            'monolog.fingerscrossed.level'  => Logger::CRITICAL,
+        ];
 
-        if (true !== $app['debug']) {
+        
+        $log_file = getenv("ETNA_LOGFILE");
+        if (false === $log_file) {
+            // default logging to stderr
+            $monolog_options['monolog.logfile'] = "php://stderr";
+        } else {
+            $monolog_options['monolog.logfile'] = $log_file;
+            $monolog_options['monolog.rotatingfile'] = true;
+            $monolog_options['monolog.rotatingfile.maxfiles'] = 7;
+        }
+        
+        $app->register(new MonologServiceProvider(), $monolog_options);
+
+        if ($this->should_configure_syslog($is_debug_enabled)) {
             $syslog    = new SyslogHandler($app_name, "user");
             $formatter = new LineFormatter("%message% %context%");
             $syslog->setFormatter($formatter);
             $app['monolog']->pushHandler($syslog);
-
-            $this->slackLogger($app);
         }
 
+        /* 2021 - I have disabled Slack integration for the following reason:
+         *  - we use Rocket instead of Slack now
+         *  - integration with Rocket have not been tested.
+         *  - most individual api are beeing phased out.
+         */
+        // $this->setupSlackLogger($app, $is_debug_enabled);
+        
         $app['logs'] = $app['monolog'];
     }
 
-    private function slackLogger(Application $app)
+    private function setupSlackLogger(Application $app, $is_debug_enabled)
     {
+        if ($is_debug_enabled) {
+            return false;
+        }
+        
         $slack_token = getenv("SLACK_TOKEN");
         if (false === $slack_token) {
             return;
@@ -72,5 +91,43 @@ class ETNALogger implements ServiceProviderInterface
         $slack->setFormatter($slack_formatter);
         $app['monolog']->pushHandler($slack);
 
+    }
+
+    private function get_log_level(bool $debug_enabled)
+    {
+        $default_level = ($debug_enabled ? Logger::DEBUG : Logger::INFO);
+        $env_loglevel = getenv('ETNA_LOGLEVEL');
+        if (false === $env_loglevel) {
+            // ETNA_LOGLEVEL is not defined in environment
+            return $default_level;
+        }
+        switch (strtolower($env_loglevel)) {
+        case 'debug': return Logger::DEBUG;
+        case 'info':  return Logger::INFO;
+        case 'warning': return Logger::WARNING;
+        case 'error': return Logger::ERROR;
+        case 'critical': return Logger::CRITICAL;
+        default: return $default_level;
+        }
+    }
+
+    private function should_configure_syslog(bool $debug_enabled)
+    {
+        if ($debug_enabled) {
+            return false;
+        }
+
+        $env_syslog = getenv('ETNA_SYSLOG_ENABLED');
+        if (false === $env_syslog) {
+            return false;
+        }
+        switch (strtolower($env_syslog)) {
+        case '1':
+        case 'yes':
+        case 'true':
+            return true;
+        default:
+            return false;
+        }
     }
 }


### PR DESCRIPTION
The main reason for this commit is adhering more closely to 12-factor-app
guidelines, as part of our migration to docker. one can now use the
following env variable to configure logging:

* `ETNA_LOGLEVEL` - (debug,info,warning,error,critical)
* `ETNA_LOGFILE` - path to a file, where to output logs. When used,
  stderr logging is disabled.
* `ETNA_SYSLOG_ENABLED` - enable logging to syslog
